### PR TITLE
#78 windows OS fix for select element

### DIFF
--- a/blocks/contact-form/contact-form.css
+++ b/blocks/contact-form/contact-form.css
@@ -3,6 +3,10 @@
     flex-direction: column;
 }
 
+#contact select option {
+    background-color: var(--background-color);
+}
+
 .contact-form-wrapper .thanks-title {
     font-size: 1rem;
 }


### PR DESCRIPTION
On MacOS not have this issue, only in Windows environment, where the _option_ tag in a _select_ element is more styleable

Fix #78 

Test URLs:
- Before: https://main--vg-partsasist--hlxsites.hlx.page/
- After: https://78-drop-down-white-against-white--vg-partsasist--hlxsites.hlx.page/
