### PR TITLE
106 Pardot Select options have background color

### DIFF
--- a/blocks/pardot-form/pardot-form.css
+++ b/blocks/pardot-form/pardot-form.css
@@ -1,3 +1,4 @@
+.pardot-form-container select option,
 .pardot-form-container {
     background-color: var(--background-color);
 }


### PR DESCRIPTION
# Fix

On Windows OS, Selects elements can be styled, so the default background is white, but we add the color as white, so this fix changes the _background-color_ in the options elements to replicate the Previous form fix

#

### Fix #106

Test URLs:
- Before: https://main--vg-partsasist--hlxsites.hlx.page/
- After: https://106-white-text-select-in-windows--vg-partsasist--hlxsites.hlx.page/
