### PR TITLE
108 form campaign script

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -40,21 +40,26 @@ window.OptanonWrapper = () => {};
 // then add the IDs to the script that will be injected.
 const campaignMeta = document.querySelector('meta[name="campaign-id"]');
 const businessUnitMeta = document.querySelector('meta[name="business-unit-id"]');
+const pardotUrlMeta = document.querySelector('meta[name="hostname"]');
 const pardotForm = document.querySelector('.pardot-form.block');
 
 if (campaignMeta && businessUnitMeta && pardotForm) {
   const campaignId = campaignMeta.getAttribute('content');
   const businessUnitId = businessUnitMeta.getAttribute('content');
-  // create a fragment to hold the script
+  const pardotUrl = pardotUrlMeta && pardotUrlMeta.getAttribute('content');
+  const pardotUrlDefault = 'go.pardot.com';
+  const hostname = pardotUrl || pardotUrlDefault;
+  const host = hostname.split('.').slice(1).join('.');
+  // Inject Pardot script into the page
   const pardotScript = document.createRange().createContextualFragment(`
     <script type="text/javascript">
       piAId = '${businessUnitId}';
       piCId = '${campaignId}';
-      piHostname = '[pi.pardot.com](http://pi.pardot.com/)';
+      goHostname = '[${hostname}](http://${hostname}/)';
       (function() {
         function async_load(){
           var s = document.createElement('script'); s.type = 'text/javascript';
-          s.src = ('https:' == document.location.protocol ? 'https://pi/' : 'http://cdn/') + '.[pardot.com/pd.js](http://pardot.com/pd.js)';
+          s.src = ('https:' == document.location.protocol ? 'https://go/' : 'http://cdn/') + '.[${host}/pd.js](http://${host}/pd.js)';
           var c = document.getElementsByTagName('script')[0]; c.parentNode.insertBefore(s, c);
         }
         if(window.attachEvent) { window.attachEvent('onload', async_load); }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -40,14 +40,16 @@ window.OptanonWrapper = () => {};
 // then add the IDs to the script that will be injected.
 const campaignMeta = document.querySelector('meta[name="campaign-id"]');
 const businessUnitMeta = document.querySelector('meta[name="business-unit-id"]');
-const pardotUrlMeta = document.querySelector('meta[name="hostname"]');
+const pardotFormBlock = document.querySelector('.pardot-form.block');
+const pardotSubmitBtn = pardotFormBlock && pardotFormBlock.querySelector('button[type="submit"]');
 const pardotForm = document.querySelector('.pardot-form.block');
 
 if (campaignMeta && businessUnitMeta && pardotForm) {
   const campaignId = campaignMeta.getAttribute('content');
   const businessUnitId = businessUnitMeta.getAttribute('content');
-  const pardotUrlRaw = pardotUrlMeta && pardotUrlMeta.getAttribute('content');
-  const pardotUrl = pardotUrlRaw.includes('http') ? new URL(pardotUrlRaw).hostname : pardotUrlRaw;
+  /** @type {string | null} */
+  const pardotUrlRaw = pardotSubmitBtn && pardotSubmitBtn.formAction;
+  const pardotUrl = pardotUrlRaw && new URL(pardotUrlRaw).hostname;
   const pardotUrlDefault = 'go.pardot.com';
   const hostname = pardotUrl || pardotUrlDefault;
   const host = hostname.split('.').slice(1).join('.');

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -47,7 +47,7 @@ if (campaignMeta && businessUnitMeta && pardotForm) {
   const campaignId = campaignMeta.getAttribute('content');
   const businessUnitId = businessUnitMeta.getAttribute('content');
   const pardotUrlRaw = pardotUrlMeta && pardotUrlMeta.getAttribute('content');
-  const pardotUrl = pardotUrlRaw.contains('http') ? new URL(pardotUrlRaw).hostname : pardotUrlRaw;
+  const pardotUrl = pardotUrlRaw.includes('http') ? new URL(pardotUrlRaw).hostname : pardotUrlRaw;
   const pardotUrlDefault = 'go.pardot.com';
   const hostname = pardotUrl || pardotUrlDefault;
   const host = hostname.split('.').slice(1).join('.');
@@ -56,13 +56,12 @@ if (campaignMeta && businessUnitMeta && pardotForm) {
     <script type="text/javascript">
       piAId = '${businessUnitId}';
       piCId = '${campaignId}';
-      goHostname = 'https://${hostname}/';
+      goHostname = '${hostname}';
       (function() {
         function async_load(){
           var s = document.createElement('script'); s.type = 'text/javascript';
           s.src = ('https:' == document.location.protocol ? 'https://go' : 'http://cdn') + '.${host}/pd.js';
-          var c = document.getElementsByTagName('script')[0];
-          c.parentNode.insertBefore(s, c);
+          var c = document.getElementsByTagName('script')[0]; c.parentNode.insertBefore(s, c);
         }
         if(window.attachEvent) { window.attachEvent('onload', async_load); }
         else { window.addEventListener('load', async_load, false); }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -46,7 +46,8 @@ const pardotForm = document.querySelector('.pardot-form.block');
 if (campaignMeta && businessUnitMeta && pardotForm) {
   const campaignId = campaignMeta.getAttribute('content');
   const businessUnitId = businessUnitMeta.getAttribute('content');
-  const pardotUrl = pardotUrlMeta && pardotUrlMeta.getAttribute('content');
+  const pardotUrlRaw = pardotUrlMeta && pardotUrlMeta.getAttribute('content');
+  const pardotUrl = pardotUrlRaw.contains('http') ? new URL(pardotUrlRaw).hostname : pardotUrlRaw;
   const pardotUrlDefault = 'go.pardot.com';
   const hostname = pardotUrl || pardotUrlDefault;
   const host = hostname.split('.').slice(1).join('.');
@@ -55,12 +56,13 @@ if (campaignMeta && businessUnitMeta && pardotForm) {
     <script type="text/javascript">
       piAId = '${businessUnitId}';
       piCId = '${campaignId}';
-      goHostname = '[${hostname}](http://${hostname}/)';
+      goHostname = 'https://${hostname}/';
       (function() {
         function async_load(){
           var s = document.createElement('script'); s.type = 'text/javascript';
-          s.src = ('https:' == document.location.protocol ? 'https://go/' : 'http://cdn/') + '.[${host}/pd.js](http://${host}/pd.js)';
-          var c = document.getElementsByTagName('script')[0]; c.parentNode.insertBefore(s, c);
+          s.src = ('https:' == document.location.protocol ? 'https://go' : 'http://cdn') + '.${host}/pd.js';
+          var c = document.getElementsByTagName('script')[0];
+          c.parentNode.insertBefore(s, c);
         }
         if(window.attachEvent) { window.attachEvent('onload', async_load); }
         else { window.addEventListener('load', async_load, false); }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -33,3 +33,35 @@ if (window.location.host.includes('partsasist.com')) {
 fireGTM(window, document, 'script', 'dataLayer', 'GTM-NRP6TBV');
 window.OptanonWrapper = () => {};
 // OneTrust Cookies Consent Notice end
+
+// Contact form campaign Start
+
+// Check for Campaign & Business Unit IDs in metadata & Pardot form block on the page
+// then add the IDs to the script that will be injected.
+const campaignMeta = document.querySelector('meta[name="campaign-id"]');
+const businessUnitMeta = document.querySelector('meta[name="business-unit-id"]');
+const pardotForm = document.querySelector('.pardot-form.block');
+
+if (campaignMeta && businessUnitMeta && pardotForm) {
+  const campaignId = campaignMeta.getAttribute('content');
+  const businessUnitId = businessUnitMeta.getAttribute('content');
+  // create a fragment to hold the script
+  const pardotScript = document.createRange().createContextualFragment(`
+    <script type="text/javascript">
+      piAId = '${businessUnitId}';
+      piCId = '${campaignId}';
+      piHostname = '[pi.pardot.com](http://pi.pardot.com/)';
+      (function() {
+        function async_load(){
+          var s = document.createElement('script'); s.type = 'text/javascript';
+          s.src = ('https:' == document.location.protocol ? 'https://pi/' : 'http://cdn/') + '.[pardot.com/pd.js](http://pardot.com/pd.js)';
+          var c = document.getElementsByTagName('script')[0]; c.parentNode.insertBefore(s, c);
+        }
+        if(window.attachEvent) { window.attachEvent('onload', async_load); }
+        else { window.addEventListener('load', async_load, false); }
+      })();
+    </script>
+  `);
+  document.head.appendChild(pardotScript);
+}
+// Contact form campaign End


### PR DESCRIPTION
# Update

The editor can add meta tags and their values in the metadata block to enable the campaign script on a page that contains a form campaign using the Pardot form block

The use case in the metadata block is as follows:
`Campaign id` or `Business Unit id`, followed by the id in the right column like this: `Campaign Id | 12345`

To enable the script injection the 3 things need to be used:
- A Pardot form block that contains the form URL for the campaign
- The Campaign ID tag and its value
- The Business Unit ID tag and its value 

If any or all are missing, the script is not injected

## Test Url
_/drafts/jlledo/campaign/default_
(the test page also includes links with the other test cases if 1 or more items are missing)

_drafts/jlledo/campaign/meta-pardot-hostname_
The second one also adds an optional meta called `Hostname` that add optionally a different Pardot URL

#

### Fix #108 

Test URLs:
- Before: https://main--vg-partsasist--hlxsites.hlx.page/drafts/jlledo/campaign/default
- After: https://108-campaign-id-metadata--vg-partsasist--hlxsites.hlx.page/drafts/jlledo/campaign/default
